### PR TITLE
Allow forking by way of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ if __name__ == "__main__":
 
 * `AUTODYNATRACE_CAPTURE_HEADERS`: Default: `False`, set to `True` to capture request headers
 * `AUTODYNATRACE_LOG_LEVEL`: Default `WARNING`
+* `AUTODYNATRACE_FORKABLE`: Default `False`, set to `True` to allow OneAgent to run in forked process
+  * https://github.com/Dynatrace/OneAgent-SDK-for-Python#using-the-oneagent-sdk-for-python-with-forked-child-processes-only-available-on-linux

--- a/autodynatrace/__init__.py
+++ b/autodynatrace/__init__.py
@@ -11,7 +11,9 @@ from .sdk import init as sdk_init
 
 log_level_name = os.environ.get("AUTODYNATRACE_LOG_LEVEL", "WARNING")
 log_init(logging.getLevelName(log_level_name))
-sdk_init()
+
+forkable = os.environ.get("AUTODYNATRACE_FORKABLE", "False").strip().lower() in ('true', '1')
+sdk_init(forkable=forkable)
 
 from .wrappers.custom import dynatrace_custom_tracer as trace
 
@@ -28,11 +30,6 @@ INSTRUMENT_LIBS = {
     "django": True,
     "redis": True,
 }
-
-
-def set_forkable():
-    sdk.shutdown()
-    sdk.init(forkable=True)
 
 
 def instrument_all(**instrument_libs):

--- a/autodynatrace/wrappers/utils.py
+++ b/autodynatrace/wrappers/utils.py
@@ -1,0 +1,6 @@
+def func_name(view_func):
+    return view_func.__name__
+
+
+def normalize_vendor(name):
+    return name


### PR DESCRIPTION
Currently, we need to manually patch the library to allow forking. Allowing forking by way of environment variables, we would be able to cut down on the complexity of our code. 